### PR TITLE
Update last mod is disabled with other buttons

### DIFF
--- a/src/manager/LinkManager.java
+++ b/src/manager/LinkManager.java
@@ -5242,6 +5242,7 @@ public class LinkManager extends JFrame implements DisableGUIInput,DebugCapable{
         dbSearchButton.setEnabled(enabled);
         dbSearchField.setEnabled(enabled);
         dbSearchPrefixCheckBox.setEnabled(dbUsedPrefixCombo.isEnabled());
+        dbUpdateLastModButton.setEnabled(enabled);
         updateDBSearchPrefixCombo();
         updateExecuteQueryEnabled();
         updatePrefixButtons();


### PR DESCRIPTION
The "Update Last Mod" button now gets enabled and disabled along with the other buttons.